### PR TITLE
Enable reauth for Realms.

### DIFF
--- a/src/main/java/me/axieum/mcmod/authme/mixin/RealmsGenericErrorScreenMixin.java
+++ b/src/main/java/me/axieum/mcmod/authme/mixin/RealmsGenericErrorScreenMixin.java
@@ -1,0 +1,65 @@
+package me.axieum.mcmod.authme.mixin;
+
+import com.mojang.realmsclient.gui.screens.RealmsGenericErrorScreen;
+import me.axieum.mcmod.authme.AuthMe;
+import me.axieum.mcmod.authme.gui.AuthScreen;
+import net.minecraft.client.gui.screen.DisconnectedScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.AbstractButtonWidget;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.realms.RealmsScreen;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RealmsGenericErrorScreen.class)
+public abstract class RealmsGenericErrorScreenMixin extends RealmsScreen
+{
+    @Shadow
+    @Final
+    private Text line1;
+
+    @Shadow
+    @Final
+    private Screen parent;
+
+    protected RealmsGenericErrorScreenMixin(Text line1, Text line2, Screen parent) { super(); }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void init(CallbackInfo info)
+    {
+        // Determine if the disconnection reason is session related
+        if (line1 == null || !getTranslationKey(line1).startsWith("mco.error.invalid.session")) return;
+
+        final AbstractButtonWidget backButton = this.buttons.get(0);
+
+        // Inject the authentication button where the back button was
+        AuthMe.LOGGER.debug("Injecting authentication button into disconnection screen");
+        this.addButton(new ButtonWidget(backButton.x,
+                backButton.y,
+                backButton.getWidth(),
+                20,
+                new TranslatableText("gui.authme.disconnect.button.auth"),
+                button -> this.client.openScreen(new AuthScreen(parent))));
+
+        // Move back button below
+        backButton.y += 26;
+    }
+
+    /**
+     * Returns the translation key for a text component.
+     *
+     * @param component text component
+     * @return translation key of translation text component else empty string
+     */
+    private static String getTranslationKey(Text component)
+    {
+        return component instanceof TranslatableText ? ((TranslatableText) component).getKey()
+                : "";
+    }
+}

--- a/src/main/java/me/axieum/mcmod/authme/mixin/RealmsGenericErrorScreenMixin.java
+++ b/src/main/java/me/axieum/mcmod/authme/mixin/RealmsGenericErrorScreenMixin.java
@@ -3,7 +3,6 @@ package me.axieum.mcmod.authme.mixin;
 import com.mojang.realmsclient.gui.screens.RealmsGenericErrorScreen;
 import me.axieum.mcmod.authme.AuthMe;
 import me.axieum.mcmod.authme.gui.AuthScreen;
-import net.minecraft.client.gui.screen.DisconnectedScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
 import net.minecraft.client.gui.widget.ButtonWidget;

--- a/src/main/java/me/axieum/mcmod/authme/mixin/RealmsMainScreenMixin.java
+++ b/src/main/java/me/axieum/mcmod/authme/mixin/RealmsMainScreenMixin.java
@@ -1,0 +1,32 @@
+package me.axieum.mcmod.authme.mixin;
+
+import com.mojang.realmsclient.RealmsMainScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.Session;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RealmsMainScreen.class)
+public interface RealmsMainScreenMixin
+{
+    @Accessor(value="checkedClientCompatability")
+    @Mutable
+    static void setCheckedClientCompatability(boolean checkedClientCompatability){
+        // Method body is ignored.
+        throw new UnsupportedOperationException();
+    };
+
+    @Accessor(value="realmsGenericErrorScreen")
+    @Mutable
+    static void setRealmsGenericErrorScreen(Screen realmsGenericErrorScreen){
+        // Method body is ignored.
+        throw new UnsupportedOperationException();
+    };
+
+}

--- a/src/main/java/me/axieum/mcmod/authme/mixin/RealmsMainScreenMixin.java
+++ b/src/main/java/me/axieum/mcmod/authme/mixin/RealmsMainScreenMixin.java
@@ -2,31 +2,18 @@ package me.axieum.mcmod.authme.mixin;
 
 import com.mojang.realmsclient.RealmsMainScreen;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.util.Session;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RealmsMainScreen.class)
 public interface RealmsMainScreenMixin
 {
-    @Accessor(value="checkedClientCompatability")
+    @Accessor
     @Mutable
-    static void setCheckedClientCompatability(boolean checkedClientCompatability){
-        // Method body is ignored.
-        throw new UnsupportedOperationException();
-    };
+    static void setCheckedClientCompatability(boolean checkedClientCompatability) {}
 
-    @Accessor(value="realmsGenericErrorScreen")
+    @Accessor
     @Mutable
-    static void setRealmsGenericErrorScreen(Screen realmsGenericErrorScreen){
-        // Method body is ignored.
-        throw new UnsupportedOperationException();
-    };
-
+    static void setRealmsGenericErrorScreen(Screen realmsGenericErrorScreen) {}
 }

--- a/src/main/java/me/axieum/mcmod/authme/util/SessionUtil.java
+++ b/src/main/java/me/axieum/mcmod/authme/util/SessionUtil.java
@@ -6,7 +6,6 @@ import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication;
-import com.mojang.realmsclient.RealmsMainScreen;
 import com.mojang.util.UUIDTypeAdapter;
 import me.axieum.mcmod.authme.AuthMe;
 import me.axieum.mcmod.authme.api.Status;
@@ -160,7 +159,8 @@ public class SessionUtil
     {
         // NB: Minecraft#session is a final property - use mixin accessor
         ((SetSessionMixin) MinecraftClient.getInstance()).setSession(session);
-        // Necessary for Realms to re-check for a valid session.
+
+        // Necessary for Realms to re-check for a valid session
         RealmsMainScreenMixin.setCheckedClientCompatability(false);
         RealmsMainScreenMixin.setRealmsGenericErrorScreen(null);
 

--- a/src/main/java/me/axieum/mcmod/authme/util/SessionUtil.java
+++ b/src/main/java/me/axieum/mcmod/authme/util/SessionUtil.java
@@ -6,9 +6,11 @@ import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
 import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication;
+import com.mojang.realmsclient.RealmsMainScreen;
 import com.mojang.util.UUIDTypeAdapter;
 import me.axieum.mcmod.authme.AuthMe;
 import me.axieum.mcmod.authme.api.Status;
+import me.axieum.mcmod.authme.mixin.RealmsMainScreenMixin;
 import me.axieum.mcmod.authme.mixin.SetSessionMixin;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.Session;
@@ -158,6 +160,9 @@ public class SessionUtil
     {
         // NB: Minecraft#session is a final property - use mixin accessor
         ((SetSessionMixin) MinecraftClient.getInstance()).setSession(session);
+        // Necessary for Realms to re-check for a valid session.
+        RealmsMainScreenMixin.setCheckedClientCompatability(false);
+        RealmsMainScreenMixin.setRealmsGenericErrorScreen(null);
 
         // Cached status is now stale
         lastStatus = Status.UNKNOWN;

--- a/src/main/resources/authme.mixins.json
+++ b/src/main/resources/authme.mixins.json
@@ -7,6 +7,8 @@
   "client": [
     "MultiplayerScreenMixin",
     "DisconnectedScreenMixin",
+    "RealmsMainScreenMixin",
+    "RealmsGenericErrorScreenMixin",
     "SetSessionMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Thanks for this great mod! 

It works great with Realms servers currently, but only if you never click "realms" while your login is expired -- as soon as it fails once, Realms never checks again. This should fix that and add the button to the "Invalid session" realms page, too. :)