### PR TITLE
Automatically save Microsoft accounts to config

### DIFF
--- a/src/main/java/me/axieum/mcmod/authme/impl/config/AuthMeConfig.java
+++ b/src/main/java/me/axieum/mcmod/authme/impl/config/AuthMeConfig.java
@@ -76,6 +76,43 @@ public class AuthMeConfig implements ConfigData
 
             @Comment("Minecraft profile url")
             public String mcProfileUrl = "https://api.minecraftservices.com/minecraft/profile";
+
+            @ConfigEntry.Gui.Excluded
+            public MicrosoftAuthTokens tokens = new MicrosoftAuthTokens();
+        }
+
+
+        public static class MicrosoftAuthTokens {
+            @Comment("Microsoft access token (keep secret)")
+            public String msAccessToken = "";
+
+            @Comment("Microsoft refresh token (keep secret)")
+            public String msRefreshToken = "";
+
+            @Comment("Microsoft access token expiration")
+            public long msAccessExpiration = -1;
+
+            @Comment("Minecraft access token (keep secret)")
+            public String mcAccessToken = "";
+
+            @Comment("Minecraft access token expiration")
+            public long mcAccessExpiration = -1;
+
+            @Comment("XBL token (keep secret)")
+            public String xblToken = "";
+
+            @Comment("XBL token expiration")
+            public long xblExpiration = -1;
+
+            @Comment("XSTS token (keep secret)")
+            public String xstsToken = "";
+
+            @Comment("XSTS UHS")
+            public String xstsUhs = "";
+
+            @Comment("XSTS expiration")
+            public long xstsExpiration = -1;
+
         }
 
         @Comment("Login via Mojang (or legacy)")

--- a/src/main/resources/assets/authme/lang/en_us.json
+++ b/src/main/resources/assets/authme/lang/en_us.json
@@ -17,6 +17,7 @@
 
   "gui.authme.microsoft.title": "Login via Microsoft",
   "gui.authme.microsoft.browser": "You may now close this window and return to Minecraft!",
+  "gui.authme.microsoft.status.loggingIn": "Logging in...",
   "gui.authme.microsoft.status.checkBrowser": "Please check your browser...",
   "gui.authme.microsoft.status.msAccessToken": "Acquiring Microsoft access token...",
   "gui.authme.microsoft.status.xboxAccessToken": "Acquiring Xbox access token...",


### PR DESCRIPTION
Will save all relevant tokens to the config file after login and use them for subsequent authentication attempts. Does not currently implement ways to force the mod to use a new account (I am bad at Minecraft UI). Mojang accounts are not implemented because session servers no longer authenticate them. Would appreciate additional testing and review.