### PR TITLE
You don't need the entire Fabric API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ allprojects {
         modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
         // Mods
-        modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+        include(fabricApi.module("fabric-api-base", project.fabric_version))
+        modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", project.fabric_version))
+        modImplementation include(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
         modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
         modImplementation include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}")
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,8 @@
     "java": ">=17",
     "minecraft": "1.19.x",
     "fabricloader": ">=0.11.3",
-    "fabric": "*",
+    "fabric-lifecycle-events-v1": "*",
+    "fabric-resource-loader-v0": "*",
     "cloth-config2": "*"
   },
   "suggests": {


### PR DESCRIPTION
Some of your dependencies still think they do, so it still completely trashes the dev env with 45 modules of build time, but you don't. This means *downstream* dev environments don't have to pay the cost of the entire Fabric API, which will immensely speed up builds for people who want to use AuthMe to debug something that only happens on a specific multiplayer server (i.e. MineHut).

This also lets you JiJ only the required modules so people can install AuthMe by itself on a client.