### PR TITLE
Fix 'Chat disabled due to missing profile public key' error

### DIFF
--- a/src/main/java/me/axieum/mcmod/authme/api/util/MicrosoftUtils.java
+++ b/src/main/java/me/axieum/mcmod/authme/api/util/MicrosoftUtils.java
@@ -572,7 +572,7 @@ public final class MicrosoftUtils
                                        mcToken,
                                        Optional.empty(),
                                        Optional.empty(),
-                                       Session.AccountType.MOJANG
+                                       Session.AccountType.MSA
                                    );
                                })
                                // Otherwise, throw an exception with the error description if present


### PR DESCRIPTION
This was caused by the session object's type being AccountType.MOJANG instead of AccountType.MSA. Because of this, the profile public key failed to generate.