### PR TITLE
Update Dependencies to Support Minecraft 1.21.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
     id 'com.modrinth.minotaur' version '2.8.7'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.8-SNAPSHOT'
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,18 @@ mod_id = authme
 mod_name = Auth Me
 mod_description = Authenticate yourself in Minecraft and re-validate your session
 ## {x-release-please-start-version}
-mod_version = 8.0.0+1.21
+mod_version = 8.0.1+1.21.3
 ## {x-release-please-end}
 
 # Fabric
-minecraft_version = 1.21
-loader_version = 0.15.11
-yarn_mappings = 1.21+build.1
-fabric_version = 0.100.1+1.21
+minecraft_version=1.21.3
+loader_version=0.16.7
+yarn_mappings=1.21.3+build.2
+fabric_version=0.107.0+1.21.3
 
 # Dependencies
-cloth_config_version = 15.0.127
-mod_menu_version = 11.0.0-beta.1
+cloth_config_version = 16.0.141
+mod_menu_version = 12.0.0-beta.1
 
 checkstyle_version = 10.15.0
 jetbrains_annotations_version = 24.1.0
@@ -22,7 +22,7 @@ junit_jupiter_version = 5.10.2
 
 # CurseForge
 cf_project_id = 356643
-cf_game_versions = Fabric, Java 21, 1.21
+cf_game_versions = Fabric, Java 21, 1.21.3
 cf_relations_required = fabric-api
 cf_relations_optional = modmenu
 cf_relations_embedded = cloth-config
@@ -31,7 +31,7 @@ cf_relations_incompatible =
 
 # Modrinth
 mr_project_id = yjgIrBjZ
-mr_game_versions = 1.21
+mr_game_versions = 1.21.3
 mr_relations_required = P7dR8mSH
 mr_relations_optional = mOgUt4GM
 mr_relations_incompatible =

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,22 +3,22 @@ mod_id = authme
 mod_name = Auth Me
 mod_description = Authenticate yourself in Minecraft and re-validate your session
 ## {x-release-please-start-version}
-mod_version = 8.0.1+1.21.3
+mod_version = 8.0.0+1.21
 ## {x-release-please-end}
 
 # Fabric
-minecraft_version=1.21.3
-loader_version=0.16.7
-yarn_mappings=1.21.3+build.2
-fabric_version=0.107.0+1.21.3
+minecraft_version = 1.21.3
+loader_version = 0.16.7
+yarn_mappings = 1.21.3+build.2
+fabric_version = 0.107.0+1.21.3
 
 # Dependencies
 cloth_config_version = 16.0.141
 mod_menu_version = 12.0.0-beta.1
 
-checkstyle_version = 10.15.0
-jetbrains_annotations_version = 24.1.0
-junit_jupiter_version = 5.10.2
+checkstyle_version = 10.20.0
+jetbrains_annotations_version = 26.0.1
+junit_jupiter_version = 5.11.3
 
 # CurseForge
 cf_project_id = 356643

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
+++ b/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
@@ -255,7 +255,18 @@ public class AuthButtonWidget extends TexturedButtonWidget
             default -> u = 16;
         }
 
-        context.drawTexture(gui -> RenderLayer.getGuiTexturedOverlay(SESSION_STATUS_TEXTURE), SESSION_STATUS_TEXTURE, getX() + width - 6, getY() - 1, u, 0, 8, 8, 24, 8);
+        context.drawTexture(
+            gui -> RenderLayer.getGuiTexturedOverlay(SESSION_STATUS_TEXTURE),
+            SESSION_STATUS_TEXTURE,
+            getX() + width - 6,
+            getY() - 1,
+            u,
+            0,
+            8,
+            8,
+            24,
+            8
+        );
     }
 
     /**

--- a/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
+++ b/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
@@ -1,5 +1,6 @@
 package me.axieum.mcmod.authme.api.gui.widget;
 
+import net.minecraft.client.render.RenderLayer;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.gui.DrawContext;
@@ -253,7 +254,8 @@ public class AuthButtonWidget extends TexturedButtonWidget
             case OFFLINE -> u = 8;
             default -> u = 16;
         }
-        context.drawTexture(SESSION_STATUS_TEXTURE, getX() + width - 6, getY() - 1, u, 0, 8, 8, 24, 8);
+
+        context.drawTexture(gui -> RenderLayer.getGuiTexturedOverlay(SESSION_STATUS_TEXTURE), SESSION_STATUS_TEXTURE, getX() + width - 6, getY() - 1, u, 0, 8, 8, 24, 8);
     }
 
     /**

--- a/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
+++ b/src/main/java/me/axieum/mcmod/authme/api/gui/widget/AuthButtonWidget.java
@@ -1,6 +1,5 @@
 package me.axieum.mcmod.authme.api.gui.widget;
 
-import net.minecraft.client.render.RenderLayer;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.gui.DrawContext;
@@ -9,6 +8,7 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TexturedButtonWidget;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 


### PR DESCRIPTION
### Update Dependencies to Support Minecraft 1.21.3

#### Summary

This pull request updates dependencies to support **Minecraft 1.21.3**. Key changes made:

- Updated `fabric-loom` to version 1.8-SNAPSHOT in `build.gradle`.
- Incremented mod version to 8.0.1 and updated Minecraft, loader, yarn mappings, and other dependencies in `gradle.properties`.
- Upgraded Gradle wrapper to 8.10 in `gradle-wrapper.properties`.
- Updated `AuthButtonWidget` by adding `RenderLayer.getGuiTexturedOverlay` now required by `yarn`.

#### Problem Statement

This update addresses the need for compatibility with Minecraft 1.21.3, ensuring the mod stays current with the latest Minecraft and Fabric API versions.

#### Justification

Updating dependencies to help ensure compatibility with the latest Minecraft version, and access to recent changes in external libraries.

#### Quality Assurance

- Verified that dependencies align with Minecraft 1.21.3.
- Tested rendering changes in `AuthButtonWidget` to ensure proper functionality with `RenderLayer.getGuiTexturedOverlay`.