### PR TITLE
Fix wrong thread exception when calling setMessage outside execute

### DIFF
--- a/common/src/main/java/me/axieum/mcmod/authme/api/gui/screen/MicrosoftAuthScreen.java
+++ b/common/src/main/java/me/axieum/mcmod/authme/api/gui/screen/MicrosoftAuthScreen.java
@@ -150,8 +150,8 @@ public class MicrosoftAuthScreen extends AuthScreen
                 client.execute(() -> {
                     statusWidget.setMessage(Component.translatable(key).withStyle(ChatFormatting.RED));
                     AuthScreen.centerPosition(statusWidget, this, 0, 15);
+                    cancelBtn.setMessage(Component.translatable("gui.back"));
                 });
-                cancelBtn.setMessage(Component.translatable("gui.back"));
                 return null; // return a default value
             });
     }


### PR DESCRIPTION
Calling `cancelBtn.setMessage()` outside `client.execute()` triggers a Minecraft wrong thread exception, as GUI widget operations must run on the render thread.

So I moved `cancelBtn.setMessage()` inside the `client.execute()` lambda to enforce render thread execution.